### PR TITLE
Install peerdeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@babel/preset-react": "^7.14.5",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.1",
+        "eslint-config-airbnb-base": "^14.2.1",
         "eslint-plugin-import": "^2.25.2",
         "eslint-plugin-jsx-a11y": "^6.4.1",
         "eslint-plugin-react": "^7.26.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@babel/preset-react": "^7.14.5",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",
+    "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.26.1",


### PR DESCRIPTION
I was having the issue that is given below:

**Failed to load config "airbnb" to extend from.
Referenced from: /app/.eslintrc.json**

I found a link here: https://github.com/airbnb/javascript/issues/2202

and I ran this command `npm install -g install-peerdeps 
install-peerdeps --dev eslint-config-airbnb-base`